### PR TITLE
fix slug with params

### DIFF
--- a/lib/ffaker/internet.rb
+++ b/lib/ffaker/internet.rb
@@ -74,8 +74,7 @@ module FFaker
 
     def slug(words = nil, glue = nil)
       glue ||= SLUG_DELIMITERS.sample
-
-      (words || FFaker::Lorem::words(2).join(glue)).downcase
+      (words || FFaker::Lorem::words(2).join(' ')).downcase.gsub(/[^a-z0-9]+/, glue)
     end
 
     def password(min_length = 8, max_length = 16)

--- a/test/test_internet.rb
+++ b/test/test_internet.rb
@@ -65,6 +65,14 @@ class TestFakerInternet < Test::Unit::TestCase
     assert @tester.slug.match(/^[a-z]+(_|\.|\-)[a-z]+$/)
   end
 
+  def test_slug_with_input_words
+    assert @tester.slug('Input Words&&Symbols').match(/^[a-z]+(_|\.|\-)[a-z]+(_|\.|\-)[a-z]+$/)
+  end
+
+  def test_slug_with_specified_glue
+    assert @tester.slug(nil, '-').match(/^[a-z]+(\-)[a-z]+$/)
+  end
+
   def test_password
     assert @tester.password.match(/[a-z]+/)
   end


### PR DESCRIPTION
Fixes a bug in Internet::slug where providing input words would not result in a valid slug.

Also adds a test for a specifying a glue symbol which was working but not tested.
